### PR TITLE
Improve repo listing format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-repos-manager-mcp",
-  "version": "1.1.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-repos-manager-mcp",
-      "version": "1.1.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.4.0",

--- a/src/formatters/repository.cjs
+++ b/src/formatters/repository.cjs
@@ -1,12 +1,13 @@
 // src/formatters/repository.cjs
 
+const { toMarkdownTable } = require("../utils/markdown.cjs");
+
 function formatListReposOutput(reposData) {
   if (!Array.isArray(reposData)) {
     console.error(
       "formatListReposOutput: reposData is not an array",
       reposData
     );
-    // Potentially return an error structure or an empty list message
     return {
       content: [
         { type: "text", text: "Error: Could not retrieve repository list." },
@@ -14,31 +15,23 @@ function formatListReposOutput(reposData) {
       isError: true,
     };
   }
-  const formatted = reposData.map((repo) => ({
-    name: repo.full_name,
-    description: repo.description || "No description",
-    private: repo.private,
-    language: repo.language || "N/A",
-    stars: repo.stargazers_count,
-    forks: repo.forks_count,
-    updated: repo.updated_at,
-    url: repo.html_url,
-  }));
+
+  const table = toMarkdownTable(reposData, [
+    {
+      header: "Repository",
+      accessor: (r) => `[${r.full_name}](${r.html_url})${r.private ? " (private)" : ""}`,
+    },
+    { header: "Description", accessor: (r) => r.description || "No description" },
+    { header: "Language", accessor: (r) => r.language || "N/A" },
+    { header: "Stars", accessor: "stargazers_count" },
+    { header: "Forks", accessor: "forks_count" },
+  ]);
 
   return {
     content: [
       {
         type: "text",
-        text: `Found ${reposData.length} repositories:\n\n${formatted
-          .map(
-            (repo) =>
-              `**${repo.name}** ${repo.private ? "(private)" : "(public)"}\n` +
-              `Description: ${repo.description}\n` +
-              `Language: ${repo.language} | Stars: ${repo.stars} | Forks: ${repo.forks}\n` +
-              `Updated: ${new Date(repo.updated).toLocaleDateString()}\n` +
-              `URL: ${repo.url}\n`
-          )
-          .join("\n")}`,
+        text: `Found ${reposData.length} repositories:\n\n${table}`,
       },
     ],
   };

--- a/src/utils/markdown.cjs
+++ b/src/utils/markdown.cjs
@@ -1,0 +1,19 @@
+function toMarkdownTable(items, columns) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return '';
+  }
+  const headers = columns.map(col => col.header);
+  const headerLine = `| ${headers.join(' | ')} |`;
+  const separatorLine = `| ${headers.map(() => '---').join(' | ')} |`;
+  const rows = items.map(item => {
+    const cells = columns.map(col => {
+      const value = typeof col.accessor === 'function'
+        ? col.accessor(item)
+        : item[col.accessor];
+      return String(value ?? '');
+    });
+    return `| ${cells.join(' | ')} |`;
+  });
+  return [headerLine, separatorLine, ...rows].join('\n');
+}
+module.exports = { toMarkdownTable };


### PR DESCRIPTION
## Summary
- add a small markdown helper
- output repo listings as markdown tables
- sync `package-lock.json` version with `package.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f38394ee88320bf6b81eb14066fa5